### PR TITLE
Enhance route parsing to support dynamic paths using AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,27 @@ You can configure the extension via VS Code Settings:
 - `hono.request.extraArgs` (string[])
   - Extra arguments appended to `hono request` and `hono serve`
 
-## Supported route syntax (current)
+## Supported route syntax
 
-- Route path must be a **string literal**:
-  - `app.get('/path', ...)`
-  - `app.get("/path", ...)`
-  - ``app.get(`/path`, ...)``
+Route paths can be defined using:
+
+- **String literals**: `app.get('/path', ...)`
+  - Single quotes: `app.get('/api', ...)`
+  - Double quotes: `app.get("/api", ...)`
+  - Template literals: ``app.get(`/api`, ...)``
+
+- **Constants**: `app.get(API_PATH, ...)` where `const API_PATH = '/api'`
+
+- **String concatenation**: 
+  - Literal + Literal: `app.get('/api' + '/users', ...)`
+  - Constant + Literal: `app.get(BASE_PATH + '/users', ...)`
+  - Literal + Constant: `app.get('/v1' + API_PATH, ...)`
+
+- **Template literals with variables**: ``app.get(`/api/${version}/users`, ...)``
+  - Shows pattern in CodeLens: `/api/${version}/users`
+  - Variables are displayed as placeholders
+
+**Not supported**: Routes defined in loops, conditionally, or with complex runtime logic.
 
 ## Troubleshooting
 

--- a/src/features/request/routeParser.test.ts
+++ b/src/features/request/routeParser.test.ts
@@ -37,4 +37,136 @@ describe('parseRoutesFromText', () => {
     expect(routes).toHaveLength(1)
     expect(routes[0]?.path).toBe('/ok')
   })
+
+  describe('dynamic route patterns', () => {
+    it('parses routes with constant references', () => {
+      const text = [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        "const API_PATH = '/api';",
+        "const USERS_PATH = '/users';",
+        'app.get(API_PATH, (c) => c.text("api"));',
+        'app.post(USERS_PATH, (c) => c.text("users"));',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text)
+      expect(routes).toHaveLength(2)
+      expect(routes[0]?.method).toBe('get')
+      expect(routes[0]?.path).toBe('/api')
+      expect(routes[1]?.method).toBe('post')
+      expect(routes[1]?.path).toBe('/users')
+    })
+
+    it('parses routes with string concatenation', () => {
+      const text = [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        "app.get('/api' + '/users', (c) => c.json([]));",
+        'app.post("/posts" + "/create", (c) => c.text("created"));',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text)
+      expect(routes).toHaveLength(2)
+      expect(routes[0]?.method).toBe('get')
+      expect(routes[0]?.path).toBe('/api/users')
+      expect(routes[1]?.method).toBe('post')
+      expect(routes[1]?.path).toBe('/posts/create')
+    })
+
+    it('parses routes with constant concatenation', () => {
+      const text = [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        "const BASE = '/api';",
+        "app.get(BASE + '/users', (c) => c.json([]));",
+        'app.post("/v1" + BASE, (c) => c.text("ok"));',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text)
+      expect(routes).toHaveLength(2)
+      expect(routes[0]?.method).toBe('get')
+      expect(routes[0]?.path).toBe('/api/users')
+      expect(routes[1]?.method).toBe('post')
+      expect(routes[1]?.path).toBe('/v1/api')
+    })
+
+    it('parses routes with template literals containing variables', () => {
+      const text = [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        'const version = "v1";',
+        'const resource = "users";',
+        'app.get(`/api/${version}/users`, (c) => c.json([]));',
+        'app.post(`/api/${version}/${resource}`, (c) => c.text("ok"));',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text)
+      expect(routes).toHaveLength(2)
+      expect(routes[0]?.method).toBe('get')
+      expect(routes[0]?.path).toBe('/api/${version}/users')
+      expect(routes[1]?.method).toBe('post')
+      expect(routes[1]?.path).toBe('/api/${version}/${resource}')
+    })
+
+    it('parses routes with no-substitution template literals', () => {
+      const text = [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        'app.get(`/api/users`, (c) => c.json([]));',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text)
+      expect(routes).toHaveLength(1)
+      expect(routes[0]?.method).toBe('get')
+      expect(routes[0]?.path).toBe('/api/users')
+    })
+
+    it('parses routes with mixed constant and template literals', () => {
+      const text = [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        "const BASE_PATH = '/api';",
+        'const version = "v2";',
+        'app.get(`${BASE_PATH}/${version}/users`, (c) => c.json([]));',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text)
+      expect(routes).toHaveLength(1)
+      expect(routes[0]?.method).toBe('get')
+      expect(routes[0]?.path).toBe('${BASE_PATH}/${version}/users')
+    })
+
+    it('handles multiple route methods', () => {
+      const text = [
+        "import { Hono } from 'hono';",
+        'const app = new Hono();',
+        "const API = '/api';",
+        'app.get(API, (c) => c.text("get"));',
+        'app.post(API, (c) => c.text("post"));',
+        'app.put(API, (c) => c.text("put"));',
+        'app.delete(API, (c) => c.text("delete"));',
+        'app.patch(API, (c) => c.text("patch"));',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text)
+      expect(routes).toHaveLength(5)
+      expect(routes.map((r) => r.method)).toEqual(['get', 'post', 'put', 'delete', 'patch'])
+      expect(routes.every((r) => r.path === '/api')).toBe(true)
+    })
+
+    it('ignores dynamic routes in comments', () => {
+      const text = [
+        'const app = new Hono();',
+        'const API_PATH = "/api";',
+        '// app.get(API_PATH, () => {})',
+        '/* app.post(API_PATH, () => {}) */',
+        'app.get(API_PATH, () => {})',
+      ].join('\n')
+
+      const routes = parseRoutesFromText(text, { excludeComments: true })
+      expect(routes).toHaveLength(1)
+      expect(routes[0]?.path).toBe('/api')
+    })
+  })
 })
+

--- a/src/features/request/routeParser.ts
+++ b/src/features/request/routeParser.ts
@@ -1,3 +1,5 @@
+import ts from 'typescript'
+
 export type ParsedRoute = {
   method: string
   path: string
@@ -18,9 +20,25 @@ type Range = {
 // actual start index of the route call. Without this, match.index can point at a newline at the
 // end of the previous line, causing CodeLens to appear one line above.
 const ROUTE_CALL_RE =
-  /(^|[^\w$])([A-Za-z_$][\w$]*)\s*\.\s*(get|post|put|delete|patch|options|head)\s*\(\s*(['"`])([^'"`]+)\4/gm
+  /(^|[^\w$])([A-Za-z_$][\w$]*)\s*\.\s*(get|post|put|delete|patch|options|head)\s*\(/gm
 
 export function parseRoutesFromText(
+  text: string,
+  opts?: { excludeComments?: boolean }
+): ParsedRoute[] {
+  // Try AST-based parsing first for better dynamic route support
+  try {
+    const astRoutes = parseRoutesWithAST(text, opts)
+    if (astRoutes.length > 0) return astRoutes
+  } catch {
+    // Fall back to regex if AST parsing fails
+  }
+
+  // Fallback: regex-based parsing (original implementation)
+  return parseRoutesWithRegex(text, opts)
+}
+
+function parseRoutesWithRegex(
   text: string,
   opts?: { excludeComments?: boolean }
 ): ParsedRoute[] {
@@ -33,10 +51,18 @@ export function parseRoutesFromText(
   while ((match = ROUTE_CALL_RE.exec(text))) {
     const prefix = match[1] ?? ''
     const method = match[3]?.toLowerCase()
-    const routePath = match[5]
-    if (!method || !routePath) continue
+    if (!method) continue
 
     const callStartIndex = match.index + prefix.length
+
+    // Try to extract path from simple string literal after opening paren
+    const afterParen = text.slice(match.index + match[0].length)
+    const pathMatch = afterParen.match(/^\s*(['"`])([^'"`]+)\1/)
+    if (!pathMatch) continue
+
+    const routePath = pathMatch[2]
+    if (!routePath) continue
+
     if (commentRanges.length > 0 && isInRanges(callStartIndex, commentRanges)) continue
 
     routes.push({
@@ -47,6 +73,116 @@ export function parseRoutesFromText(
   }
 
   return routes
+}
+
+function parseRoutesWithAST(
+  text: string,
+  opts?: { excludeComments?: boolean }
+): ParsedRoute[] {
+  const sourceFile = ts.createSourceFile('temp.ts', text, ts.ScriptTarget.Latest, true)
+  const routes: ParsedRoute[] = []
+  const commentRanges = opts?.excludeComments === false ? [] : findCommentRanges(text)
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const methodName = node.expression.name.text
+      const validMethods = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head']
+
+      if (validMethods.includes(methodName)) {
+        const firstArg = node.arguments[0]
+        if (firstArg) {
+          const resolvedPath = resolveRoutePathExpression(firstArg, sourceFile)
+          if (resolvedPath) {
+            const callStartIndex = node.expression.expression.getStart(sourceFile, false)
+
+            if (commentRanges.length > 0 && isInRanges(callStartIndex, commentRanges)) {
+              ts.forEachChild(node, visit)
+              return
+            }
+
+            routes.push({
+              method: methodName.toLowerCase(),
+              path: resolvedPath,
+              callStartIndex,
+            })
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return routes
+}
+
+function resolveRoutePathExpression(node: ts.Node, sourceFile: ts.SourceFile): string | null {
+  // Direct string literal
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text
+  }
+
+  // Template literal with substitutions: convert to pattern
+  if (ts.isTemplateExpression(node)) {
+    return stringifyTemplateExpression(node)
+  }
+
+  // Identifier: resolve to constant
+  if (ts.isIdentifier(node)) {
+    return evaluateConstantString(node, sourceFile)
+  }
+
+  // Binary expression: evaluate string concatenation
+  if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = resolveRoutePathExpression(node.left, sourceFile)
+    const right = resolveRoutePathExpression(node.right, sourceFile)
+    if (left !== null && right !== null) {
+      return left + right
+    }
+  }
+
+  return null
+}
+
+function evaluateConstantString(identifier: ts.Identifier, sourceFile: ts.SourceFile): string | null {
+  const varName = identifier.text
+  let result: string | null = null
+
+  const visit = (node: ts.Node) => {
+    if (result !== null) return // Already found
+
+    // Variable declaration: const API_PATH = '/api'
+    if (ts.isVariableDeclaration(node)) {
+      if (ts.isIdentifier(node.name) && node.name.text === varName && node.initializer) {
+        const resolved = resolveRoutePathExpression(node.initializer, sourceFile)
+        if (resolved !== null) {
+          result = resolved
+          return
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return result
+}
+
+function stringifyTemplateExpression(template: ts.TemplateExpression): string {
+  let result = template.head.text
+
+  for (const span of template.templateSpans) {
+    // Add placeholder for the expression
+    if (ts.isIdentifier(span.expression)) {
+      result += `\${${span.expression.text}}`
+    } else {
+      result += '${...}'
+    }
+    result += span.literal.text
+  }
+
+  return result
 }
 
 function isInRanges(pos: number, ranges: Range[]): boolean {


### PR DESCRIPTION
This pull request significantly improves the route parsing logic to support more dynamic and expressive route definitions in Hono applications. The changes introduce an AST-based parser that can resolve routes defined with constants, string concatenation, and template literals (including variables and mixed expressions), making the extension much more robust and accurate. The documentation and test coverage have also been updated to reflect and verify these new capabilities.

**Route Parsing Improvements:**

* Added an AST-based parser in `routeParser.ts` that supports extracting routes defined as string literals, constants, string concatenations, and template literals with variables or mixed expressions. This includes logic for resolving constants and evaluating binary expressions for concatenation. [[1]](diffhunk://#diff-101dcb29948d39b70d56f08862a79de984e799f31ddb2c190771a707337d88c5R1-R2) [[2]](diffhunk://#diff-101dcb29948d39b70d56f08862a79de984e799f31ddb2c190771a707337d88c5L21-R43) [[3]](diffhunk://#diff-101dcb29948d39b70d56f08862a79de984e799f31ddb2c190771a707337d88c5R78-R187)
* Updated the fallback regex-based parser to work alongside the AST parser for backward compatibility and as a safety net.

**Documentation Updates:**

* Expanded the "Supported route syntax" section in `README.md` to describe the new supported patterns, including constants, concatenations, and template literals, and clarified unsupported cases.

**Testing Enhancements:**

* Added comprehensive test cases in `routeParser.test.ts` to cover routes defined using constants, string concatenation, template literals (with and without variables), mixed expressions, and to ensure comments are properly ignored.

**Type Inference Consistency:**

* Refactored `typeInference.ts` to use the new `resolveRoutePathExpression` logic, ensuring that type inference works with the expanded set of supported route definitions. [[1]](diffhunk://#diff-f363e07aafa141945085325f1b36dd56d5875189f16051e56818a7acde6dec92L122-R131) [[2]](diffhunk://#diff-f363e07aafa141945085325f1b36dd56d5875189f16051e56818a7acde6dec92R144-R212)