### PR TITLE
feat: add entry point selection for hono request command

### DIFF
--- a/src/features/request/argvBuilder.test.ts
+++ b/src/features/request/argvBuilder.test.ts
@@ -32,4 +32,48 @@ describe('buildBundledHonoRequestArgv', () => {
       '--foo',
     ])
   })
+
+  it('builds argv with app entry file', () => {
+    const argv = buildBundledHonoRequestArgv({
+      entry: '/ext/node_modules/@hono/cli/dist/cli.js',
+      watch: false,
+      input: {
+        method: 'get',
+        path: '/hello',
+        appEntryFile: 'src/app.ts',
+      },
+      extraArgs: [],
+    })
+
+    expect(argv).toEqual([
+      '/ext/node_modules/@hono/cli/dist/cli.js',
+      'request',
+      'src/app.ts',
+      '-P',
+      '/hello',
+      '-X',
+      'GET',
+    ])
+  })
+
+  it('builds argv without app entry file when not provided', () => {
+    const argv = buildBundledHonoRequestArgv({
+      entry: '/ext/node_modules/@hono/cli/dist/cli.js',
+      watch: false,
+      input: {
+        method: 'get',
+        path: '/hello',
+      },
+      extraArgs: [],
+    })
+
+    expect(argv).toEqual([
+      '/ext/node_modules/@hono/cli/dist/cli.js',
+      'request',
+      '-P',
+      '/hello',
+      '-X',
+      'GET',
+    ])
+  })
 })

--- a/src/features/request/argvBuilder.ts
+++ b/src/features/request/argvBuilder.ts
@@ -3,6 +3,7 @@ export type RequestInvocationInput = {
   path: string
   data?: string
   headers?: string[]
+  appEntryFile?: string
 }
 
 export function buildBundledHonoRequestArgv(params: {
@@ -15,6 +16,7 @@ export function buildBundledHonoRequestArgv(params: {
   return [
     entry,
     'request',
+    ...(input.appEntryFile ? [input.appEntryFile] : []),
     '-P',
     input.path,
     '-X',

--- a/src/features/request/entryPointResolver.test.ts
+++ b/src/features/request/entryPointResolver.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as vscode from 'vscode'
+import { findEntryPointCandidates } from './entryPointResolver'
+
+vi.mock('node:fs')
+vi.mock('vscode', () => ({
+  Uri: {
+    parse: (uri: string) => ({ fsPath: uri.replace('file://', '') }),
+  },
+}))
+
+describe('findEntryPointCandidates', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('includes candidate when file contains both "new Hono" and ".route"', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/workspace/src/index.ts')
+    vi.mocked(fs.readFileSync).mockReturnValue(`
+      const app = new Hono()
+      app.route('/api', apiRoutes)
+      export default app
+    `)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/other.ts')
+
+    expect(result).toContain('src/index.ts')
+  })
+
+  it('excludes candidate when file contains only "new Hono"', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/workspace/src/index.ts')
+    vi.mocked(fs.readFileSync).mockReturnValue(`
+      const app = new Hono()
+      app.get('/', (c) => c.text('Hello'))
+      export default app
+    `)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/other.ts')
+
+    expect(result).not.toContain('src/index.ts')
+  })
+
+  it('excludes candidate when file contains only ".route"', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/workspace/src/index.ts')
+    vi.mocked(fs.readFileSync).mockReturnValue(`
+      app.route('/api', apiRoutes)
+    `)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/other.ts')
+
+    expect(result).not.toContain('src/index.ts')
+  })
+
+  it('excludes candidate when file does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/other.ts')
+
+    expect(result).not.toContain('src/index.ts')
+    expect(fs.readFileSync).not.toHaveBeenCalled()
+  })
+
+  it('adds currently editing file at the beginning if not in candidates', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/src/routes/user.ts')
+
+    expect(result[0]).toBe('src/routes/user.ts')
+  })
+
+  it('does not duplicate currently editing file if already in candidates', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/workspace/src/index.ts')
+    vi.mocked(fs.readFileSync).mockReturnValue(`
+      const app = new Hono()
+      app.route('/api', apiRoutes)
+    `)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/src/index.ts')
+
+    expect(result.filter((c) => c === 'src/index.ts')).toHaveLength(1)
+  })
+
+  it('excludes candidate when "new Hono" is in a line comment', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/workspace/src/index.ts')
+    vi.mocked(fs.readFileSync).mockReturnValue(`
+      // const app = new Hono()
+      app.route('/api', apiRoutes)
+    `)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/other.ts')
+
+    expect(result).not.toContain('src/index.ts')
+  })
+
+  it('excludes candidate when ".route" is in a block comment', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/workspace/src/index.ts')
+    vi.mocked(fs.readFileSync).mockReturnValue(`
+      const app = new Hono()
+      /* app.route('/api', apiRoutes) */
+    `)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/other.ts')
+
+    expect(result).not.toContain('src/index.ts')
+  })
+
+  it('includes candidate when both are outside comments', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === '/workspace/src/index.ts')
+    vi.mocked(fs.readFileSync).mockReturnValue(`
+      // This is a comment about new Hono
+      const app = new Hono()
+      /* route setup below */
+      app.route('/api', apiRoutes)
+    `)
+
+    const result = findEntryPointCandidates('/workspace', 'file:///workspace/other.ts')
+
+    expect(result).toContain('src/index.ts')
+  })
+})

--- a/src/features/request/entryPointResolver.test.ts
+++ b/src/features/request/entryPointResolver.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as fs from 'node:fs'
-import * as vscode from 'vscode'
 import { findEntryPointCandidates } from './entryPointResolver'
 
 vi.mock('node:fs')

--- a/src/features/request/entryPointResolver.ts
+++ b/src/features/request/entryPointResolver.ts
@@ -26,7 +26,7 @@ export function findEntryPointCandidates(workspaceRoot: string, currentFileUri: 
   const relativeCurrent = path.relative(workspaceRoot, currentFilePath)
 
   if (!candidates.includes(relativeCurrent)) {
-    candidates.push(relativeCurrent)
+    candidates.unshift(relativeCurrent)
   }
 
   return candidates

--- a/src/features/request/entryPointResolver.ts
+++ b/src/features/request/entryPointResolver.ts
@@ -1,0 +1,95 @@
+import * as vscode from 'vscode'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { InputHistory, historyKey, workspaceKeyForUri } from '../../shared/inputHistory'
+
+const ENTRY_CANDIDATES = [
+  'src/index.ts',
+  'src/index.tsx',
+  'src/index.js',
+  'src/index.jsx',
+] as const
+
+/**
+ * Find entry point candidates in the workspace.
+ * Checks for standard entry files and includes the currently editing file.
+ */
+export function findEntryPointCandidates(
+  workspaceRoot: string,
+  currentFileUri: string
+): string[] {
+  const candidates: string[] = []
+
+  // Check standard entry candidates
+  for (const candidate of ENTRY_CANDIDATES) {
+    const fullPath = path.join(workspaceRoot, candidate)
+    if (fs.existsSync(fullPath)) {
+      candidates.push(candidate)
+    }
+  }
+
+  // Add the currently editing file (if not already included)
+  const currentFilePath = vscode.Uri.parse(currentFileUri).fsPath
+  const relativeCurrent = path.relative(workspaceRoot, currentFilePath)
+
+  if (!candidates.includes(relativeCurrent)) {
+    candidates.push(relativeCurrent)
+  }
+
+  return candidates
+}
+
+/**
+ * Resolve the entry point for hono request.
+ * If only one candidate exists, use it automatically.
+ * If multiple candidates exist, show QuickPick and remember the selection.
+ */
+export async function resolveEntryPoint(
+  workspaceRoot: string,
+  currentFileUri: string,
+  history: InputHistory
+): Promise<string | undefined> {
+  const candidates = findEntryPointCandidates(workspaceRoot, currentFileUri)
+
+  if (candidates.length === 0) {
+    void vscode.window.showErrorMessage(
+      'No entry point found. Expected src/index.ts, src/index.tsx, src/index.js, or src/index.jsx'
+    )
+    return undefined
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0]
+  }
+
+  // Multiple candidates: show QuickPick
+  const wsKey = workspaceKeyForUri(currentFileUri)
+  const currentFilePath = vscode.Uri.parse(currentFileUri).fsPath
+  const currentFileRelative = path.relative(workspaceRoot, currentFilePath)
+  const histKey = historyKey('entryPoint', wsKey, currentFileRelative)
+  const previousSelection = history.get(histKey)
+
+  // Sort candidates: previous selection first, then standard candidates, then current file
+  const sortedCandidates = [...candidates]
+  if (previousSelection && sortedCandidates.includes(previousSelection)) {
+    sortedCandidates.splice(sortedCandidates.indexOf(previousSelection), 1)
+    sortedCandidates.unshift(previousSelection)
+  }
+
+  const items: vscode.QuickPickItem[] = sortedCandidates.map((c, i) => ({
+    label: c,
+    description: i === 0 && c === previousSelection ? '(last used)' : undefined,
+  }))
+
+  const selected = await vscode.window.showQuickPick(items, {
+    placeHolder: 'Select entry point for hono request',
+    ignoreFocusOut: true,
+  })
+
+  if (!selected) return undefined // canceled
+
+  // Save selection
+  await history.set(histKey, selected.label)
+
+  return selected.label
+}

--- a/src/features/request/entryPointResolver.ts
+++ b/src/features/request/entryPointResolver.ts
@@ -32,7 +32,7 @@ export function findEntryPointCandidates(workspaceRoot: string, currentFileUri: 
     // Immediate return if the current file is an well-known entry point
     return [relativeCurrent]
   }
-  
+
   const candidates: string[] = [relativeCurrent]
 
   // Check standard entry candidates
@@ -40,7 +40,10 @@ export function findEntryPointCandidates(workspaceRoot: string, currentFileUri: 
     const fullPath = path.join(workspaceRoot, candidate)
     if (fs.existsSync(fullPath)) {
       const content = fs.readFileSync(fullPath, 'utf-8')
-      if (containsOutsideComments(content, 'new Hono') && containsOutsideComments(content, '.route')) {
+      if (
+        containsOutsideComments(content, 'new Hono') &&
+        containsOutsideComments(content, '.route')
+      ) {
         candidates.push(candidate)
       }
     }

--- a/src/features/request/entryPointResolver.ts
+++ b/src/features/request/entryPointResolver.ts
@@ -1,23 +1,16 @@
 import * as vscode from 'vscode'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { InputHistory, historyKey, workspaceKeyForUri } from '../../shared/inputHistory'
+import type { InputHistory } from '../../shared/inputHistory'
+import { historyKey, workspaceKeyForUri } from '../../shared/inputHistory'
 
-const ENTRY_CANDIDATES = [
-  'src/index.ts',
-  'src/index.tsx',
-  'src/index.js',
-  'src/index.jsx',
-] as const
+const ENTRY_CANDIDATES = ['src/index.ts', 'src/index.tsx', 'src/index.js', 'src/index.jsx'] as const
 
 /**
  * Find entry point candidates in the workspace.
  * Checks for standard entry files and includes the currently editing file.
  */
-export function findEntryPointCandidates(
-  workspaceRoot: string,
-  currentFileUri: string
-): string[] {
+export function findEntryPointCandidates(workspaceRoot: string, currentFileUri: string): string[] {
   const candidates: string[] = []
 
   // Check standard entry candidates

--- a/src/features/request/entryPointResolver.ts
+++ b/src/features/request/entryPointResolver.ts
@@ -17,7 +17,10 @@ export function findEntryPointCandidates(workspaceRoot: string, currentFileUri: 
   for (const candidate of ENTRY_CANDIDATES) {
     const fullPath = path.join(workspaceRoot, candidate)
     if (fs.existsSync(fullPath)) {
-      candidates.push(candidate)
+      const content = fs.readFileSync(fullPath, 'utf-8')
+      if (content.includes('new Hono') && content.includes('.route')) {
+        candidates.push(candidate)
+      }
     }
   }
 

--- a/src/features/request/entryPointResolver.ts
+++ b/src/features/request/entryPointResolver.ts
@@ -5,7 +5,7 @@ import { findCommentRanges, isIndexInRanges } from '../../shared/commentRanges'
 import type { InputHistory } from '../../shared/inputHistory'
 import { historyKey, workspaceKeyForUri } from '../../shared/inputHistory'
 
-const ENTRY_CANDIDATES = ['src/index.ts', 'src/index.tsx', 'src/index.js', 'src/index.jsx'] as const
+const ENTRY_CANDIDATES = ['src/index.ts', 'src/index.tsx', 'src/index.js', 'src/index.jsx']
 
 function containsOutsideComments(content: string, needle: string): boolean {
   const commentRanges = findCommentRanges(content)
@@ -24,7 +24,16 @@ function containsOutsideComments(content: string, needle: string): boolean {
  * Checks for standard entry files and includes the currently editing file.
  */
 export function findEntryPointCandidates(workspaceRoot: string, currentFileUri: string): string[] {
-  const candidates: string[] = []
+  // Add the currently editing file (if not already included)
+  const currentFilePath = vscode.Uri.parse(currentFileUri).fsPath
+  const relativeCurrent = path.relative(workspaceRoot, currentFilePath)
+
+  if (ENTRY_CANDIDATES.includes(relativeCurrent)) {
+    // Immediate return if the current file is an well-known entry point
+    return [relativeCurrent]
+  }
+  
+  const candidates: string[] = [relativeCurrent]
 
   // Check standard entry candidates
   for (const candidate of ENTRY_CANDIDATES) {
@@ -35,14 +44,6 @@ export function findEntryPointCandidates(workspaceRoot: string, currentFileUri: 
         candidates.push(candidate)
       }
     }
-  }
-
-  // Add the currently editing file (if not already included)
-  const currentFilePath = vscode.Uri.parse(currentFileUri).fsPath
-  const relativeCurrent = path.relative(workspaceRoot, currentFilePath)
-
-  if (!candidates.includes(relativeCurrent)) {
-    candidates.unshift(relativeCurrent)
   }
 
   return candidates

--- a/src/features/request/runner.ts
+++ b/src/features/request/runner.ts
@@ -6,8 +6,8 @@ import { getRequestConfig } from '../../shared/config'
 import { InputHistory, historyKey, workspaceKeyForUri } from '../../shared/inputHistory'
 import { buildBundledHonoRequestArgv } from './argvBuilder'
 import type { RequestInvocationInput } from './argvBuilder'
-import { applyPathParams, extractPathParamNames } from './pathParams'
 import { resolveEntryPoint } from './entryPointResolver'
+import { applyPathParams, extractPathParamNames } from './pathParams'
 import type { RequestLensCommandArgs } from './types'
 
 type FormFieldSpec = {

--- a/src/features/request/runner.ts
+++ b/src/features/request/runner.ts
@@ -7,6 +7,7 @@ import { InputHistory, historyKey, workspaceKeyForUri } from '../../shared/input
 import { buildBundledHonoRequestArgv } from './argvBuilder'
 import type { RequestInvocationInput } from './argvBuilder'
 import { applyPathParams, extractPathParamNames } from './pathParams'
+import { resolveEntryPoint } from './entryPointResolver'
 import type { RequestLensCommandArgs } from './types'
 
 type FormFieldSpec = {
@@ -84,7 +85,7 @@ export async function runRequestOnce({
     return
   }
 
-  const resolved = await resolveInvocationInput(args, new InputHistory(context.globalState))
+  const resolved = await resolveInvocationInput(args, new InputHistory(context.globalState), cwd)
   if (!resolved) return
 
   let cmd: string
@@ -156,7 +157,7 @@ export async function runRequestWatchInTerminal({
     return
   }
 
-  const resolved = await resolveInvocationInput(args, new InputHistory(context.globalState))
+  const resolved = await resolveInvocationInput(args, new InputHistory(context.globalState), cwd)
   if (!resolved) return
 
   let cmd: string
@@ -215,7 +216,7 @@ export async function runRequestDebug({
 
   const cfg = getRequestConfig()
 
-  const resolved = await resolveInvocationInput(args, new InputHistory(context.globalState))
+  const resolved = await resolveInvocationInput(args, new InputHistory(context.globalState), cwd)
   if (!resolved) return
 
   let entry: string
@@ -247,6 +248,7 @@ export async function runRequestDebug({
     program: entry,
     args: [
       'request',
+      ...(resolved.appEntryFile ? [resolved.appEntryFile] : []),
       '-P',
       resolved.path,
       '-X',
@@ -276,9 +278,15 @@ function quoteForShell(s: string): string {
 
 async function resolveInvocationInput(
   args: RequestLensCommandArgs,
-  history: InputHistory
+  history: InputHistory,
+  workspaceRoot: string
 ): Promise<RequestInvocationInput | undefined> {
   const wsKey = workspaceKeyForUri(args.uri)
+
+  // Resolve entry point
+  const appEntryFile = await resolveEntryPoint(workspaceRoot, args.uri, history)
+  if (!appEntryFile) return undefined
+
   const resolvedPath = await promptPathParams(args.path, wsKey, history)
   if (!resolvedPath) return
 
@@ -286,7 +294,7 @@ async function resolveInvocationInput(
 
   // For non-body methods, we just run.
   if (!['post', 'put', 'patch', 'delete'].includes(method)) {
-    return { method, path: resolvedPath }
+    return { method, path: resolvedPath, appEntryFile }
   }
 
   const inferred = await inferFormFieldsFromHonoSchema({
@@ -298,12 +306,12 @@ async function resolveInvocationInput(
 
   if (!inferred || inferred.length === 0) {
     const raw = await promptRawBody(wsKey, history)
-    return raw === undefined ? undefined : { method, path: resolvedPath, ...raw }
+    return raw === undefined ? undefined : { method, path: resolvedPath, appEntryFile, ...raw }
   }
 
   const prompted = await promptFormBodyFromTypes(inferred, wsKey, history)
   if (!prompted) return // canceled
-  return { method, path: resolvedPath, ...prompted }
+  return { method, path: resolvedPath, appEntryFile, ...prompted }
 }
 
 async function promptPathParams(


### PR DESCRIPTION
When running hono request, the extension now detects and selects the entry point file. It searches for standard candidates (src/index.ts, src/index.tsx, src/index.js, src/index.jsx) and the currently editing file. If multiple candidates exist, a QuickPick is shown to let the user select, and the selection is remembered per editing file.

fixes #6 #7

### Files in deep directories

https://github.com/user-attachments/assets/bc07f1ac-452d-47e2-95c8-cdc85c2290e2

### src/index.ts exists, and there are multiple candidates

https://github.com/user-attachments/assets/b5840f85-4ba3-466f-bf15-ad6db649c029

