### PR TITLE
feat: add CodeLens for JSDoc @example HTTP requests

### DIFF
--- a/src/features/request/routeParser.test.ts
+++ b/src/features/request/routeParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseRoutesFromText } from './routeParser'
+import { parseJSDocExamplesFromText, parseRoutesFromText } from './routeParser'
 
 describe('parseRoutesFromText', () => {
   it('parses route method, path, and callStartIndex', () => {
@@ -36,5 +36,114 @@ describe('parseRoutesFromText', () => {
     const routes = parseRoutesFromText(text, { excludeComments: true })
     expect(routes).toHaveLength(1)
     expect(routes[0]?.path).toBe('/ok')
+  })
+})
+
+describe('parseJSDocExamplesFromText', () => {
+  it('parses single-line JSON from @example', () => {
+    const text = [
+      '/**',
+      ' * @example',
+      ' * POST { "name": "John" }',
+      ' */',
+      'app.post("/users", (c) => c.text("ok"));',
+    ].join('\n')
+
+    const examples = parseJSDocExamplesFromText(text)
+    expect(examples).toHaveLength(1)
+    expect(examples[0]?.method).toBe('post')
+    expect(examples[0]?.jsonBody).toBe('{ "name": "John" }')
+    expect(examples[0]?.routePath).toBe('/users')
+    expect(examples[0]?.routeMethod).toBe('post')
+  })
+
+  it('parses multiline JSON from @example', () => {
+    const text = [
+      '/**',
+      ' * @example',
+      ' * POST {',
+      ' *   "name": "John",',
+      ' *   "age": 30',
+      ' * }',
+      ' */',
+      'app.post("/users", (c) => c.text("ok"));',
+    ].join('\n')
+
+    const examples = parseJSDocExamplesFromText(text)
+    expect(examples).toHaveLength(1)
+    expect(examples[0]?.method).toBe('post')
+    expect(examples[0]?.jsonBody).toContain('"name": "John"')
+    expect(examples[0]?.jsonBody).toContain('"age": 30')
+    expect(examples[0]?.routePath).toBe('/users')
+  })
+
+  it('ignores @example when method does not match route', () => {
+    const text = [
+      '/**',
+      ' * @example',
+      ' * GET { "query": "test" }',
+      ' */',
+      'app.post("/users", (c) => c.text("ok"));',
+    ].join('\n')
+
+    const examples = parseJSDocExamplesFromText(text)
+    expect(examples).toHaveLength(0)
+  })
+
+  it('parses multiple @examples in one JSDoc', () => {
+    const text = [
+      '/**',
+      ' * @example',
+      ' * POST { "name": "John" }',
+      ' * @example',
+      ' * POST { "name": "Jane" }',
+      ' */',
+      'app.post("/users", (c) => c.text("ok"));',
+    ].join('\n')
+
+    const examples = parseJSDocExamplesFromText(text)
+    expect(examples).toHaveLength(2)
+    expect(examples[0]?.jsonBody).toBe('{ "name": "John" }')
+    expect(examples[1]?.jsonBody).toBe('{ "name": "Jane" }')
+  })
+
+  it('returns empty array when no @example found', () => {
+    const text = [
+      '/**',
+      ' * Some description',
+      ' */',
+      'app.post("/users", (c) => c.text("ok"));',
+    ].join('\n')
+
+    const examples = parseJSDocExamplesFromText(text)
+    expect(examples).toHaveLength(0)
+  })
+
+  it('returns empty array when no route follows JSDoc', () => {
+    const text = [
+      '/**',
+      ' * @example',
+      ' * POST { "name": "John" }',
+      ' */',
+      'const foo = "bar";',
+    ].join('\n')
+
+    const examples = parseJSDocExamplesFromText(text)
+    expect(examples).toHaveLength(0)
+  })
+
+  it('captures methodStartIndex correctly', () => {
+    const text = [
+      '/**',
+      ' * @example',
+      ' * POST { "name": "John" }',
+      ' */',
+      'app.post("/users", (c) => c.text("ok"));',
+    ].join('\n')
+
+    const examples = parseJSDocExamplesFromText(text)
+    expect(examples).toHaveLength(1)
+    const idx = examples[0]!.methodStartIndex
+    expect(text.slice(idx, idx + 4)).toBe('POST')
   })
 })

--- a/src/features/request/routeParser.ts
+++ b/src/features/request/routeParser.ts
@@ -137,3 +137,255 @@ function findCommentRanges(text: string): Range[] {
 
   return ranges
 }
+
+/**
+ * Represents a parsed @example HTTP request from JSDoc comments.
+ */
+export type ParsedJSDocExample = {
+  /** HTTP method (lowercase, e.g. "post") */
+  method: string
+  /** JSON body string extracted from @example */
+  jsonBody: string
+  /** Character index where the METHOD keyword starts in the source text */
+  methodStartIndex: number
+  /** Path from the associated route definition */
+  routePath: string
+  /** Method from the associated route definition */
+  routeMethod: string
+}
+
+/**
+ * Parses JSDoc @example blocks that contain HTTP request examples.
+ *
+ * Example pattern:
+ * ```
+ * /**
+ *  * @example
+ *  * POST { "name": "John" }
+ *  *\/
+ * app.post("/users", ...)
+ * ```
+ *
+ * This function finds such patterns and associates them with the route definition
+ * that immediately follows the JSDoc comment.
+ */
+export function parseJSDocExamplesFromText(text: string): ParsedJSDocExample[] {
+  const results: ParsedJSDocExample[] = []
+
+  // Find all JSDoc blocks: /** ... */
+  const jsdocRe = /\/\*\*[\s\S]*?\*\//g
+  let jsdocMatch: RegExpExecArray | null
+
+  while ((jsdocMatch = jsdocRe.exec(text))) {
+    const jsdocContent = jsdocMatch[0]
+    const jsdocStartIndex = jsdocMatch.index
+    const jsdocEndIndex = jsdocStartIndex + jsdocContent.length
+
+    // Find @example sections within this JSDoc block
+    const examples = parseExamplesFromJSDoc(jsdocContent, jsdocStartIndex)
+    if (examples.length === 0) continue
+
+    // Find the route definition that follows this JSDoc block
+    const followingRoute = findFollowingRoute(text, jsdocEndIndex)
+    if (!followingRoute) continue
+
+    // Associate each @example with the route (if methods match)
+    for (const example of examples) {
+      if (example.method === followingRoute.method) {
+        results.push({
+          method: example.method,
+          jsonBody: example.jsonBody,
+          methodStartIndex: example.methodStartIndex,
+          routePath: followingRoute.path,
+          routeMethod: followingRoute.method,
+        })
+      }
+    }
+  }
+
+  return results
+}
+
+type ParsedExampleInJSDoc = {
+  method: string
+  jsonBody: string
+  methodStartIndex: number
+}
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD']
+
+/**
+ * Parses @example sections from a JSDoc comment block and extracts HTTP request examples.
+ */
+function parseExamplesFromJSDoc(
+  jsdocContent: string,
+  jsdocStartIndex: number
+): ParsedExampleInJSDoc[] {
+  const results: ParsedExampleInJSDoc[] = []
+
+  // Split into lines for easier processing
+  const lines = jsdocContent.split('\n')
+  let currentLineOffset = 0
+  let inExample = false
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]!
+    const trimmedLine = stripJSDocLinePrefix(line)
+
+    // Check if this line starts an @example section
+    if (trimmedLine.startsWith('@example')) {
+      inExample = true
+      currentLineOffset += line.length + 1 // +1 for newline
+      i++
+      continue
+    }
+
+    // Check if this line starts a new @ tag (exits @example)
+    if (trimmedLine.startsWith('@') && !trimmedLine.startsWith('@example')) {
+      inExample = false
+      currentLineOffset += line.length + 1
+      i++
+      continue
+    }
+
+    // If we're in an @example section, look for HTTP METHOD {json} pattern
+    if (inExample) {
+      const methodMatch = findHttpMethodInLine(trimmedLine)
+      if (methodMatch) {
+        // Find the position of METHOD in the original line
+        const methodPosInLine = line.indexOf(methodMatch.method)
+        const methodStartIndex = jsdocStartIndex + currentLineOffset + methodPosInLine
+
+        // Extract JSON body (may span multiple lines)
+        const jsonResult = extractJsonBody(lines, i, trimmedLine, methodMatch.jsonStartInTrimmed)
+        if (jsonResult) {
+          results.push({
+            method: methodMatch.method.toLowerCase(),
+            jsonBody: jsonResult.jsonBody,
+            methodStartIndex,
+          })
+          // Skip the lines consumed by JSON extraction
+          currentLineOffset += jsonResult.consumedChars
+          i += jsonResult.consumedLines
+          continue
+        }
+      }
+    }
+
+    currentLineOffset += line.length + 1 // +1 for newline
+    i++
+  }
+
+  return results
+}
+
+/**
+ * Strips the JSDoc line prefix (leading whitespace and asterisk).
+ * e.g., " * POST {...}" -> "POST {...}"
+ */
+function stripJSDocLinePrefix(line: string): string {
+  return line.replace(/^\s*\*?\s?/, '')
+}
+
+/**
+ * Finds an HTTP method at the start of a line and returns info about it.
+ */
+function findHttpMethodInLine(
+  trimmedLine: string
+): { method: string; jsonStartInTrimmed: number } | null {
+  for (const method of HTTP_METHODS) {
+    if (trimmedLine.startsWith(method)) {
+      const afterMethod = trimmedLine.slice(method.length)
+      // Ensure there's whitespace or { after the method
+      if (/^\s*\{/.test(afterMethod) || /^\s+/.test(afterMethod)) {
+        const jsonStart = trimmedLine.indexOf('{')
+        if (jsonStart !== -1) {
+          return { method, jsonStartInTrimmed: jsonStart }
+        }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Extracts a JSON body starting from a given position, handling multiline JSON.
+ */
+function extractJsonBody(
+  lines: string[],
+  startLineIndex: number,
+  startTrimmedLine: string,
+  jsonStartInTrimmed: number
+): { jsonBody: string; consumedLines: number; consumedChars: number } | null {
+  let jsonStr = ''
+  let braceCount = 0
+  let started = false
+  let consumedLines = 0
+  let consumedChars = 0
+
+  // Start from the current line at the JSON start position
+  let content = startTrimmedLine.slice(jsonStartInTrimmed)
+
+  for (let lineIdx = startLineIndex; lineIdx < lines.length; lineIdx++) {
+    if (lineIdx > startLineIndex) {
+      content = stripJSDocLinePrefix(lines[lineIdx]!)
+    }
+
+    for (const ch of content) {
+      if (ch === '{') {
+        started = true
+        braceCount++
+        jsonStr += ch
+      } else if (ch === '}') {
+        braceCount--
+        jsonStr += ch
+        if (braceCount === 0 && started) {
+          // Completed JSON extraction
+          consumedLines = lineIdx - startLineIndex + 1
+          for (let j = startLineIndex; j <= lineIdx; j++) {
+            consumedChars += lines[j]!.length + 1
+          }
+          return { jsonBody: jsonStr.trim(), consumedLines, consumedChars }
+        }
+      } else if (started) {
+        jsonStr += ch
+      }
+    }
+
+    // Add newline between lines if continuing
+    if (started && braceCount > 0) {
+      jsonStr += '\n'
+    }
+
+    // Check if we've hit a new @ tag or end of JSDoc
+    if (lineIdx > startLineIndex) {
+      const trimmed = stripJSDocLinePrefix(lines[lineIdx]!)
+      if (trimmed.startsWith('@') || trimmed === '*/') {
+        break
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Finds the first route definition after the given index in the text.
+ */
+function findFollowingRoute(
+  text: string,
+  startIndex: number
+): { method: string; path: string } | null {
+  const searchText = text.slice(startIndex)
+  ROUTE_CALL_RE.lastIndex = 0
+
+  const match = ROUTE_CALL_RE.exec(searchText)
+  if (!match) return null
+
+  const method = match[3]?.toLowerCase()
+  const path = match[5]
+  if (!method || !path) return null
+
+  return { method, path }
+}

--- a/src/features/request/runner.ts
+++ b/src/features/request/runner.ts
@@ -297,6 +297,19 @@ async function resolveInvocationInput(
     return { method, path: resolvedPath, appEntryFile }
   }
 
+  // If jsonBody is provided from @example, use it directly with application/json
+  if (args.jsonBody) {
+    return {
+      method,
+      path: resolvedPath,
+      appEntryFile,
+      data: args.jsonBody,
+      headers: [
+        args.contentType ? `Content-Type: ${args.contentType}` : 'Content-Type: application/json',
+      ],
+    }
+  }
+
   const inferred = await inferFormFieldsFromHonoSchema({
     uri: args.uri,
     line: args.line,

--- a/src/features/request/types.ts
+++ b/src/features/request/types.ts
@@ -15,4 +15,12 @@ export type RequestLensCommandArgs = {
    * Line number where the route call was detected.
    */
   line?: number
+  /**
+   * Pre-defined JSON body from @example in JSDoc.
+   */
+  jsonBody?: string
+  /**
+   * Content-Type header (e.g. "application/json").
+   */
+  contentType?: string
 }


### PR DESCRIPTION
Add support for showing CodeLens on @example lines in JSDoc comments that contain HTTP request examples like POST { "name": "John" }. When clicked, the request is sent with application/json content type.

- Add parseJSDocExamplesFromText() to parse @example HTTP patterns
- Support multiline JSON in @example blocks
- Add jsonBody and contentType fields to RequestLensCommandArgs
- Skip body prompt when jsonBody is provided from @example


https://github.com/user-attachments/assets/e99877fc-f977-4b6a-b630-aaa557264fc7

